### PR TITLE
Handle circular references

### DIFF
--- a/tests/test_jsonlogger.py
+++ b/tests/test_jsonlogger.py
@@ -205,3 +205,12 @@ class TestJsonLogger(unittest.TestCase):
         self.logger.info(" message", extra=value)
         msg = self.buffer.getvalue()
         self.assertEqual(msg, '{"message": " message", "special": [3.0, 8.0]}\n')
+
+    def testHandlesCircularSerialisationErrorsWithFallbackToStr(self):
+        record = {"foo": "bar"}
+        record["self"] = record
+
+        fr = jsonlogger.JsonFormatter()
+        results = fr.jsonify_log_record(record)
+
+        assert results == "{'foo': 'bar', 'self': {...}}"

--- a/tests/test_jsonlogger.py
+++ b/tests/test_jsonlogger.py
@@ -221,4 +221,3 @@ class TestJsonLogger(unittest.TestCase):
         expected_message = outer_message % inner_message
         logged_msg = self.buffer.getvalue()
         self.assertEqual(logged_msg, expected_message)
-

--- a/trustpilot_json_logging/jsonlogger.py
+++ b/trustpilot_json_logging/jsonlogger.py
@@ -183,13 +183,19 @@ class JsonFormatter(logging.Formatter):
 
     def jsonify_log_record(self, log_record):
         """Returns a json string of the log record."""
-        return self.json_serializer(
-            log_record,
-            default=self.json_default,
-            cls=self.json_encoder,
-            indent=self.json_indent,
-            ensure_ascii=self.json_ensure_ascii,
-        )
+        try:
+            return self.json_serializer(
+                log_record,
+                default=self.json_default,
+                cls=self.json_encoder,
+                indent=self.json_indent,
+                ensure_ascii=self.json_ensure_ascii,
+            )
+        except ValueError as ex:
+            logging.warning(
+                f"Unable to serialise value for logging: {log_record} with error: {ex}"
+            )
+            return str(log_record)
 
     def format(self, record):
         """Formats a log record and serializes to json"""

--- a/trustpilot_json_logging/jsonlogger.py
+++ b/trustpilot_json_logging/jsonlogger.py
@@ -191,11 +191,22 @@ class JsonFormatter(logging.Formatter):
                 indent=self.json_indent,
                 ensure_ascii=self.json_ensure_ascii,
             )
-        except ValueError as ex:
-            logging.warning(
-                f"Unable to serialise value for logging: {log_record} with error: {ex}"
+        except Exception as ex:
+            message = f"Unable to serialise value for logging"
+            try:
+                # Attempt to clean OrderedDict str format
+                log_record = str(dict(log_record))
+            except:
+                log_record = str(log_record)
+            exception = f"{type(ex).__name__}: {ex}"
+            clean_record = dict(message=message, log_record=log_record, exception=exception)
+            return self.json_serializer(
+                clean_record,
+                default=self.json_default,
+                cls=self.json_encoder,
+                indent=self.json_indent,
+                ensure_ascii=self.json_ensure_ascii,
             )
-            return str(log_record)
 
     def format(self, record):
         """Formats a log record and serializes to json"""

--- a/trustpilot_json_logging/jsonlogger.py
+++ b/trustpilot_json_logging/jsonlogger.py
@@ -192,16 +192,18 @@ class JsonFormatter(logging.Formatter):
                 ensure_ascii=self.json_ensure_ascii,
             )
         except Exception as ex:
-            message = f"Unable to serialise value for logging"
             try:
                 # Attempt to clean OrderedDict str format
                 log_record = str(dict(log_record))
             except:
                 log_record = str(log_record)
-            exception = f"{type(ex).__name__}: {ex}"
-            clean_record = dict(message=message, log_record=log_record, exception=exception)
+
             return self.json_serializer(
-                clean_record,
+                dict(
+                    message="Unable to serialise value for logging",
+                    log_record=log_record,
+                    exception=f"{type(ex).__name__}: {ex}",
+                ),
                 default=self.json_default,
                 cls=self.json_encoder,
                 indent=self.json_indent,


### PR DESCRIPTION
I'm not sure if this is the best approach here, but we need some handling of this case. I've run into something deep in the connexion library that occasionally passes a circular argument to a warning log and it doesn't go well. We don't have control over logging calls inside other libraries so we need some resilience here.

Open questions:
Should we log errors about logging errors?
Is `str` the best fallback in this case?
Should we handle serialisation `TypeError`s in here too?